### PR TITLE
fix: error during playerLoaded event

### DIFF
--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -41,7 +41,6 @@ AddEventHandler('pe-core:onPlayerJoined', function()
 end)
 
 AddEventHandler('pe-core:playerLoaded', function(playerId, identifier)
-    local playerId <const> = source
     local player = Player(playerId)
 
     Utils.Debug('success', "Player ["..playerId.."] has been loaded.")


### PR DESCRIPTION
Source wont exist on a event fired by the server, source is already being passed to the event, just need to utilize it.